### PR TITLE
Potential fix for code scanning alert no. 13: DOM text reinterpreted as HTML

### DIFF
--- a/presentation/templates/profile/profile.html
+++ b/presentation/templates/profile/profile.html
@@ -404,7 +404,13 @@
         let currentEditPostId = null;
         document.querySelectorAll('.edit-post-btn').forEach(btn => {
             btn.onclick = function() {
-                currentEditPostId = this.getAttribute('data-post-id');
+                const rawPostId = this.getAttribute('data-post-id');
+                const postIdPattern = /^[a-zA-Z0-9_-]+$/; // Allow alphanumeric, underscores, and hyphens
+                if (!postIdPattern.test(rawPostId)) {
+                    console.error('Invalid post ID:', rawPostId);
+                    return; // Stop further processing if post ID is invalid
+                }
+                currentEditPostId = rawPostId;
                 const postDiv = document.querySelector('.profile-feed-item[data-post-id="' + currentEditPostId + '"]');
                 document.getElementById('editPostId').value = currentEditPostId;
                 document.getElementById('editPostContent').value = this.getAttribute('data-post-content');


### PR DESCRIPTION
Potential fix for [https://github.com/honghuat-2301911/ICT2216_Group23/security/code-scanning/13](https://github.com/honghuat-2301911/ICT2216_Group23/security/code-scanning/13)

To fix the issue, the value of `data-post-id` should be validated or sanitized before being used. This can be achieved by ensuring that `currentEditPostId` contains only safe characters (e.g., alphanumeric characters) and matches the expected format for post IDs. A regular expression can be used for validation.

**Steps to fix:**
1. Add a validation step for `currentEditPostId` after retrieving it from the `data-post-id` attribute.
2. If the value does not pass validation, handle the error gracefully (e.g., log an error or prevent further processing).
3. Ensure that the validated value is used in the concatenation for the form's `action` attribute.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
