### PR TITLE
Potential fix for code scanning alert no. 15: DOM text reinterpreted as HTML

### DIFF
--- a/presentation/templates/profile/profile.html
+++ b/presentation/templates/profile/profile.html
@@ -590,13 +590,17 @@
             btn.onclick = function() {
                 const activityDiv = this.closest('.profile-feed-item');
                 currentLeaveActivityId = activityDiv ? activityDiv.getAttribute('data-activity-id').split('-')[0] : null;
+                // Validate that currentLeaveActivityId contains only digits
+                if (!/^\d+$/.test(currentLeaveActivityId)) {
+                    currentLeaveActivityId = null;
+                }
                 leaveActivityModal.style.display = 'block';
             };
         });
         document.getElementById('confirmLeaveActivityBtn').onclick = function() {
             if (currentLeaveActivityId) {
                 const form = document.getElementById('leaveActivityForm');
-                form.action = '/profile/leave_activity/' + currentLeaveActivityId;
+                form.action = currentLeaveActivityId ? '/profile/leave_activity/' + currentLeaveActivityId : '';
                 form.submit();
             }
             leaveActivityModal.style.display = 'none';


### PR DESCRIPTION
Potential fix for [https://github.com/honghuat-2301911/ICT2216_Group23/security/code-scanning/15](https://github.com/honghuat-2301911/ICT2216_Group23/security/code-scanning/15)

To fix the issue, we need to sanitize or validate the `data-activity-id` value before using it. Since `data-activity-id` is expected to be a numeric ID, we can ensure it contains only digits by using a regular expression or JavaScript's `Number` function. If the value is not valid, we should handle it gracefully (e.g., by not setting the form's `action` attribute).

The fix involves:
1. Validating `currentLeaveActivityId` to ensure it contains only numeric characters.
2. Updating the code on line 599 to use the sanitized value.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
